### PR TITLE
Fix header accessibility

### DIFF
--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -1,9 +1,11 @@
 <template>
   <div id="app">
     <header class="app-header">
-      <h1 class="app-title" @click="goToHome">
-        <i class="pi pi-video"></i>
-        Video2Minutes
+      <h1 class="app-title">
+        <RouterLink :to="{ name: 'dashboard' }" class="home-link">
+          <i class="pi pi-video"></i>
+          Video2Minutes
+        </RouterLink>
       </h1>
       <p class="app-subtitle">動画から議事録を自動生成</p>
     </header>
@@ -17,27 +19,15 @@
 </template>
 
 <script>
-import { RouterView, useRouter } from 'vue-router'
+import { RouterView, RouterLink } from 'vue-router'
 import Toast from 'primevue/toast'
 
 export default {
   name: 'App',
   components: {
     RouterView,
+    RouterLink,
     Toast
-  },
-  setup() {
-    const router = useRouter()
-
-    const goToHome = () => {
-      if (router.currentRoute.value.name !== 'dashboard') {
-        router.push({ name: 'dashboard' })
-      }
-    }
-
-    return {
-      goToHome
-    }
   }
 }
 </script>
@@ -91,26 +81,29 @@ export default {
   font-size: 3rem;
   font-weight: 800;
   margin-bottom: var(--space-3);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-4);
   position: relative;
   z-index: 1;
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   color: white;
-  cursor: pointer;
-  transition: all 0.3s ease;
   user-select: none;
 }
 
-.app-title:hover {
+.home-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.home-link:hover {
   transform: scale(1.05);
   text-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   filter: brightness(1.1);
 }
 
-.app-title i {
+.home-link i {
   font-size: 3.5rem;
   filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
 }
@@ -147,13 +140,13 @@ export default {
     padding: var(--space-10) var(--space-4);
   }
 
-  .app-title {
+  .home-link {
     font-size: 2.25rem;
     flex-direction: column;
     gap: var(--space-3);
   }
 
-  .app-title i {
+  .home-link i {
     font-size: 2.75rem;
   }
 
@@ -171,11 +164,11 @@ export default {
     padding: var(--space-8) var(--space-3);
   }
 
-  .app-title {
+  .home-link {
     font-size: 1.875rem;
   }
 
-  .app-title i {
+  .home-link i {
     font-size: 2.25rem;
   }
 


### PR DESCRIPTION
## Summary
- make the app title a real link using `<RouterLink>`
- tidy `App.vue` styles for the new `.home-link`

## Testing
- `npm test` *(fails: Cannot find module 'vitest/dist/cli-wrapper.js')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684dcb91add8832e9aacda8ad87d6c5a