### PR TITLE
Centralize colors in global CSS

### DIFF
--- a/src/frontend/src/components/FileUploader.vue
+++ b/src/frontend/src/components/FileUploader.vue
@@ -901,7 +901,7 @@ export default {
 
 .upload-icon {
   font-size: 5rem;
-  color: #667eea;
+  color: var(--brand-500);
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
   z-index: 1;
@@ -930,7 +930,7 @@ export default {
 
 .upload-dropzone:hover .upload-icon {
   transform: scale(1.15);
-  color: #5b6de8;
+  color: var(--brand-400);
 }
 
 .upload-dropzone:hover .icon-glow {
@@ -938,7 +938,7 @@ export default {
 }
 
 .upload-dropzone.dragover .upload-icon {
-  color: #10b981;
+  color: var(--success-500);
   transform: scale(1.2);
 }
 
@@ -966,21 +966,21 @@ export default {
 .upload-text {
   font-size: 1.4rem;
   font-weight: 700;
-  color: #374151;
+  color: var(--gray-700);
   margin: 0 0 0.75rem 0;
   line-height: 1.3;
   transition: all 0.3s ease;
 }
 
 .upload-text.highlight {
-  color: #10b981;
+  color: var(--success-500);
   transform: scale(1.08);
   text-shadow: 0 2px 8px rgba(16, 185, 129, 0.3);
 }
 
 .upload-subtext {
   font-size: 1rem;
-  color: #6b7280;
+  color: var(--gray-500);
   margin: 0 0 1rem 0;
   line-height: 1.5;
   font-weight: 500;
@@ -1065,12 +1065,12 @@ export default {
   content: '';
   flex: 1;
   height: 1px;
-  background: linear-gradient(to right, transparent, #e5e7eb, transparent);
+  background: linear-gradient(to right, transparent, var(--gray-200), transparent);
 }
 
 .divider span {
   padding: 0 1rem;
-  color: #9ca3af;
+  color: var(--gray-400);
   font-size: 0.9rem;
   font-weight: 500;
   background: rgba(255, 255, 255, 0.8);
@@ -1109,7 +1109,7 @@ export default {
   font-size: 1rem;
   font-weight: 600;
   border-radius: 10px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, var(--brand-500) 0%, var(--brand-700) 100%);
   border: none;
   transition: all 0.3s ease;
   box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
@@ -1139,7 +1139,7 @@ export default {
 
 .note-content i {
   font-size: 1.1rem;
-  color: #667eea;
+  color: var(--brand-500);
   flex-shrink: 0;
 }
 
@@ -1152,7 +1152,7 @@ export default {
 }
 
 .supported-formats {
-  color: #374151;
+  color: var(--gray-700);
   font-weight: 500;
 }
 
@@ -1285,7 +1285,7 @@ export default {
   align-items: center;
   gap: 0.5rem;
   margin: 0;
-  color: #059669;
+  color: var(--success-600);
   font-size: 1.1rem;
   font-weight: 600;
 }
@@ -1303,7 +1303,7 @@ export default {
   background: white;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--gray-200);
   transition: all 0.2s ease;
 }
 
@@ -1325,7 +1325,7 @@ export default {
   justify-content: center;
   width: 48px;
   height: 48px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, var(--brand-500) 0%, var(--brand-700) 100%);
   border-radius: 10px;
   color: white;
   font-size: 1.5rem;
@@ -1339,14 +1339,14 @@ export default {
 
 .file-name {
   font-weight: 600;
-  color: #374151;
+  color: var(--gray-700);
   font-size: 1rem;
   line-height: 1.2;
 }
 
 .file-size {
   font-size: 0.9rem;
-  color: #6b7280;
+  color: var(--gray-500);
 }
 
 .file-remove-btn {
@@ -1390,7 +1390,7 @@ export default {
   align-items: center;
   gap: 0.5rem;
   margin: 0 0 1rem 0;
-  color: #3b82f6;
+  color: var(--info-500);
   font-size: 1.1rem;
   font-weight: 600;
 }
@@ -1405,7 +1405,7 @@ export default {
   border-radius: 12px;
   padding: 1.25rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--gray-200);
 }
 
 .progress-info {
@@ -1422,13 +1422,13 @@ export default {
 
 .progress-name {
   font-weight: 600;
-  color: #374151;
+  color: var(--gray-700);
   font-size: 1rem;
 }
 
 .progress-percent {
   font-weight: 700;
-  color: #3b82f6;
+  color: var(--info-500);
   font-size: 1.1rem;
 }
 
@@ -1454,7 +1454,7 @@ export default {
   font-size: 1.1rem;
   font-weight: 600;
   border-radius: 12px;
-  background: linear-gradient(135deg, #059669 0%, #047857 100%);
+  background: linear-gradient(135deg, var(--success-600) 0%, var(--success-700) 100%);
   border: none;
   transition: all 0.3s ease;
   box-shadow: 0 4px 15px rgba(5, 150, 105, 0.3);

--- a/src/frontend/src/components/MarkdownDemo.vue
+++ b/src/frontend/src/components/MarkdownDemo.vue
@@ -147,20 +147,20 @@ export default {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: #495057;
+  color: var(--gray-550);
   font-size: 1.25rem;
 }
 
 .demo-info {
   margin-top: 2rem;
   padding: 1rem;
-  background: #f8f9fa;
+  background: var(--gray-600-light);
   border-radius: 8px;
-  border-left: 4px solid #667eea;
+  border-left: 4px solid var(--brand-500);
 }
 
 .demo-info p {
   margin: 0.5rem 0;
-  color: #495057;
+  color: var(--gray-550);
 }
 </style>

--- a/src/frontend/src/components/MarkdownRenderer.vue
+++ b/src/frontend/src/components/MarkdownRenderer.vue
@@ -162,7 +162,7 @@ export default {
 }
 
 .toc-card {
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--gray-200);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
@@ -170,7 +170,7 @@ export default {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: #495057;
+  color: var(--gray-550);
   font-size: 1rem;
   font-weight: 600;
 }
@@ -218,7 +218,7 @@ export default {
 .toc-link {
   display: block;
   padding: 0.5rem 0;
-  color: #6b7280;
+  color: var(--gray-500);
   text-decoration: none;
   font-size: 0.9rem;
   line-height: 1.4;
@@ -229,8 +229,8 @@ export default {
 }
 
 .toc-link:hover {
-  color: #667eea;
-  border-left-color: #667eea;
+  color: var(--brand-500);
+  border-left-color: var(--brand-500);
   background-color: rgba(102, 126, 234, 0.05);
 }
 
@@ -240,7 +240,7 @@ export default {
 }
 
 .markdown-card {
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--gray-200);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
@@ -276,7 +276,7 @@ export default {
   font-family:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   line-height: 1.7;
-  color: #374151;
+  color: var(--gray-700);
   max-width: none;
 }
 
@@ -286,7 +286,7 @@ export default {
 
 /* Headings */
 .markdown-heading {
-  color: #1f2937;
+  color: var(--gray-800);
   font-weight: 700;
   margin: 2rem 0 1rem 0;
   line-height: 1.3;
@@ -296,14 +296,14 @@ export default {
 
 .markdown-h1 {
   font-size: 2.25rem;
-  border-bottom: 3px solid #e5e7eb;
+  border-bottom: 3px solid var(--gray-200);
   padding-bottom: 0.75rem;
   margin-bottom: 1.5rem;
 }
 
 .markdown-h2 {
   font-size: 1.875rem;
-  border-bottom: 2px solid #f3f4f6;
+  border-bottom: 2px solid var(--gray-100);
   padding-bottom: 0.5rem;
   margin-top: 2.5rem;
 }
@@ -323,7 +323,7 @@ export default {
 
 .markdown-h6 {
   font-size: 1rem;
-  color: #6b7280;
+  color: var(--gray-500);
 }
 
 .heading-highlight {
@@ -366,10 +366,10 @@ export default {
 .markdown-blockquote {
   margin: 1.5rem 0;
   padding: 1rem 1.5rem;
-  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+  background: linear-gradient(135deg, var(--gray-600-light) 0%, var(--gray-650-light) 100%);
   border-radius: 8px;
   position: relative;
-  border-left: 4px solid #667eea;
+  border-left: 4px solid var(--brand-500);
 }
 
 .blockquote-indicator {
@@ -378,12 +378,12 @@ export default {
   top: 0;
   bottom: 0;
   width: 4px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, var(--brand-500) 0%, var(--brand-700) 100%);
   border-radius: 2px;
 }
 
 .blockquote-content {
-  color: #4b5563;
+  color: var(--gray-600);
   font-style: italic;
   font-size: 1.05rem;
 }
@@ -394,8 +394,8 @@ export default {
 
 /* Code */
 .markdown-inline-code {
-  background: #f3f4f6;
-  color: #d97706;
+  background: var(--gray-100);
+  color: var(--warning-600);
   padding: 0.2rem 0.4rem;
   border-radius: 4px;
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
@@ -407,8 +407,8 @@ export default {
   margin: 1.5rem 0;
   border-radius: 8px;
   overflow: hidden;
-  background: #1f2937;
-  border: 1px solid #374151;
+  background: var(--gray-800);
+  border: 1px solid var(--gray-700);
 }
 
 .code-header {
@@ -416,20 +416,20 @@ export default {
   justify-content: space-between;
   align-items: center;
   padding: 0.75rem 1rem;
-  background: #374151;
-  border-bottom: 1px solid #4b5563;
+  background: var(--gray-700);
+  border-bottom: 1px solid var(--gray-600);
 }
 
 .code-language {
-  color: #d1d5db;
+  color: var(--gray-300);
   font-size: 0.8rem;
   font-weight: 500;
   text-transform: uppercase;
 }
 
 .code-copy-btn {
-  background: #4b5563;
-  color: #d1d5db;
+  background: var(--gray-600);
+  color: var(--gray-300);
   border: none;
   padding: 0.375rem 0.75rem;
   border-radius: 4px;
@@ -442,20 +442,20 @@ export default {
 }
 
 .code-copy-btn:hover {
-  background: #6b7280;
+  background: var(--gray-500);
   color: white;
 }
 
 .code-copy-btn.copied {
-  background: #059669;
+  background: var(--success-600);
   color: white;
 }
 
 .code-content {
   margin: 0;
   padding: 1rem;
-  background: #1f2937;
-  color: #f9fafb;
+  background: var(--gray-800);
+  color: var(--gray-50);
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
   font-size: 0.9rem;
   line-height: 1.5;
@@ -474,7 +474,7 @@ export default {
   margin: 1.5rem 0;
   overflow-x: auto;
   border-radius: 8px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--gray-200);
 }
 
 .markdown-table {
@@ -484,23 +484,23 @@ export default {
 }
 
 .markdown-table-header {
-  background: #f9fafb;
+  background: var(--gray-50);
 }
 
 .markdown-table th,
 .markdown-table td {
   padding: 0.75rem 1rem;
   text-align: left;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--gray-200);
 }
 
 .markdown-table th {
   font-weight: 600;
-  color: #374151;
+  color: var(--gray-700);
 }
 
 .markdown-table tbody tr:hover {
-  background: #f9fafb;
+  background: var(--gray-50);
 }
 
 .markdown-table tbody tr:last-child td {
@@ -510,17 +510,17 @@ export default {
 /* Text formatting */
 .markdown-strong {
   font-weight: 700;
-  color: #1f2937;
+  color: var(--gray-800);
 }
 
 .markdown-emphasis {
   font-style: italic;
-  color: #4b5563;
+  color: var(--gray-600);
 }
 
 /* Links */
 .markdown-link {
-  color: #667eea;
+  color: var(--brand-500);
   text-decoration: none;
   font-weight: 500;
   display: inline-flex;
@@ -530,7 +530,7 @@ export default {
 }
 
 .markdown-link:hover {
-  color: #5b6de8;
+  color: var(--brand-400);
   text-decoration: underline;
 }
 
@@ -548,15 +548,15 @@ export default {
 .markdown-divider hr {
   border: none;
   height: 2px;
-  background: linear-gradient(to right, transparent, #e5e7eb, transparent);
+  background: linear-gradient(to right, transparent, var(--gray-200), transparent);
   margin: 0;
 }
 
 /* Error state */
 .markdown-error {
-  color: #dc2626;
-  background: #fef2f2;
-  border: 1px solid #fecaca;
+  color: var(--error-600);
+  background: var(--error-50);
+  border: 1px solid var(--error-100);
   border-radius: 6px;
   padding: 1rem;
   font-weight: 500;

--- a/src/frontend/src/components/MinutesViewer.vue
+++ b/src/frontend/src/components/MinutesViewer.vue
@@ -466,15 +466,15 @@ ${cleanMinutesContent.value}`
         // Create header for PDF
         const header = document.createElement('div')
         header.style.marginBottom = '30px'
-        header.style.borderBottom = '2px solid #e5e7eb'
+        header.style.borderBottom = '2px solid var(--gray-200)'
         header.style.paddingBottom = '20px'
         
         const attendeesText = attendees.value.length > 0 ? attendees.value.join(', ') : '未設定'
         const meetingDateText = meetingDate.value ? formatDate(meetingDate.value) : '未設定'
         
         header.innerHTML = `
-          <h1 style="color: #374151; font-size: 24px; margin: 0 0 15px 0; font-weight: bold;">議事録</h1>
-          <div style="color: #6b7280; font-size: 12px;">
+          <h1 style="color: var(--gray-700); font-size: 24px; margin: 0 0 15px 0; font-weight: bold;">議事録</h1>
+          <div style="color: var(--gray-500); font-size: 12px;">
             <div style="margin-bottom: 5px;"><strong>ファイル名:</strong> ${minutes.value.video_filename}</div>
             <div style="margin-bottom: 5px;"><strong>作成日時:</strong> ${formatDate(minutes.value.created_at)}</div>
             <div style="margin-bottom: 5px;"><strong>開催日時:</strong> ${meetingDateText}</div>
@@ -487,7 +487,7 @@ ${cleanMinutesContent.value}`
         
         // Apply PDF-specific styles to the cloned content
         const applyPDFStyles = (element) => {
-          element.style.color = '#374151'
+          element.style.color = 'var(--gray-700)'
           element.style.fontSize = '14px'
           element.style.lineHeight = '1.6'
           
@@ -496,10 +496,10 @@ ${cleanMinutesContent.value}`
           h1Elements.forEach(h1 => {
             h1.style.fontSize = '20px'
             h1.style.fontWeight = 'bold'
-            h1.style.color = '#1f2937'
+            h1.style.color = 'var(--gray-800)'
             h1.style.marginTop = '24px'
             h1.style.marginBottom = '16px'
-            h1.style.borderBottom = '2px solid #e5e7eb'
+            h1.style.borderBottom = '2px solid var(--gray-200)'
             h1.style.paddingBottom = '8px'
           })
 
@@ -507,7 +507,7 @@ ${cleanMinutesContent.value}`
           h2Elements.forEach(h2 => {
             h2.style.fontSize = '18px'
             h2.style.fontWeight = 'bold'
-            h2.style.color = '#1f2937'
+            h2.style.color = 'var(--gray-800)'
             h2.style.marginTop = '20px'
             h2.style.marginBottom = '12px'
           })
@@ -516,7 +516,7 @@ ${cleanMinutesContent.value}`
           h3Elements.forEach(h3 => {
             h3.style.fontSize = '16px'
             h3.style.fontWeight = 'bold'
-            h3.style.color = '#1f2937'
+            h3.style.color = 'var(--gray-800)'
             h3.style.marginTop = '16px'
             h3.style.marginBottom = '8px'
           })
@@ -525,7 +525,7 @@ ${cleanMinutesContent.value}`
           const pElements = element.querySelectorAll('p')
           pElements.forEach(p => {
             p.style.marginBottom = '12px'
-            p.style.color = '#374151'
+            p.style.color = 'var(--gray-700)'
           })
 
           // Style lists
@@ -544,26 +544,26 @@ ${cleanMinutesContent.value}`
           const liElements = element.querySelectorAll('li')
           liElements.forEach(li => {
             li.style.marginBottom = '4px'
-            li.style.color = '#374151'
+            li.style.color = 'var(--gray-700)'
           })
 
           // Style strong and em
           const strongElements = element.querySelectorAll('strong')
           strongElements.forEach(strong => {
             strong.style.fontWeight = 'bold'
-            strong.style.color = '#1f2937'
+            strong.style.color = 'var(--gray-800)'
           })
 
           const emElements = element.querySelectorAll('em')
           emElements.forEach(em => {
             em.style.fontStyle = 'italic'
-            em.style.color = '#4b5563'
+            em.style.color = 'var(--gray-600)'
           })
 
           // Style code blocks
           const codeElements = element.querySelectorAll('code')
           codeElements.forEach(code => {
-            code.style.backgroundColor = '#f3f4f6'
+            code.style.backgroundColor = 'var(--gray-100)'
             code.style.padding = '2px 4px'
             code.style.borderRadius = '4px'
             code.style.fontFamily = 'monospace'
@@ -572,7 +572,7 @@ ${cleanMinutesContent.value}`
 
           const preElements = element.querySelectorAll('pre')
           preElements.forEach(pre => {
-            pre.style.backgroundColor = '#f3f4f6'
+            pre.style.backgroundColor = 'var(--gray-100)'
             pre.style.padding = '12px'
             pre.style.borderRadius = '6px'
             pre.style.overflow = 'visible'
@@ -592,15 +592,15 @@ ${cleanMinutesContent.value}`
 
           const thElements = element.querySelectorAll('th')
           thElements.forEach(th => {
-            th.style.border = '1px solid #d1d5db'
+            th.style.border = '1px solid var(--gray-300)'
             th.style.padding = '8px'
-            th.style.backgroundColor = '#f9fafb'
+            th.style.backgroundColor = 'var(--gray-50)'
             th.style.fontWeight = 'bold'
           })
 
           const tdElements = element.querySelectorAll('td')
           tdElements.forEach(td => {
-            td.style.border = '1px solid #d1d5db'
+            td.style.border = '1px solid var(--gray-300)'
             td.style.padding = '8px'
           })
 

--- a/src/frontend/src/components/TaskDetailModal.vue
+++ b/src/frontend/src/components/TaskDetailModal.vue
@@ -535,23 +535,23 @@ export default {
 
 .filename {
   font-weight: 500;
-  color: #495057;
+  color: var(--gray-550);
   word-break: break-all;
 }
 
 .progress-section h3 {
   margin: 0 0 1.5rem 0;
-  color: #374151;
+  color: var(--gray-700);
   font-size: 1.2rem;
   font-weight: 600;
-  border-bottom: 2px solid #e5e7eb;
+  border-bottom: 2px solid var(--gray-200);
   padding-bottom: 0.5rem;
 }
 
 .overall-progress {
   margin-bottom: 2rem;
   padding: 1.5rem;
-  background: linear-gradient(135deg, #f8f9fa 0%, #f1f3f4 100%);
+  background: linear-gradient(135deg, var(--gray-600-light) 0%, var(--gray-625-light) 100%);
   border-radius: 12px;
   border: 1px solid #e9ecef;
 }
@@ -643,7 +643,7 @@ export default {
 
 .step-header h4 {
   margin: 0;
-  color: #495057;
+  color: var(--gray-550);
   font-size: 1rem;
 }
 
@@ -673,12 +673,12 @@ export default {
 .eta {
   display: block;
   margin-top: 0.25rem;
-  color: #6c757d;
+  color: var(--gray-650);
 }
 
 .step-duration {
   font-size: 0.9rem;
-  color: #6c757d;
+  color: var(--gray-650);
   margin-top: 0.5rem;
 }
 
@@ -693,7 +693,7 @@ export default {
 
 .error-section h3 {
   margin: 0 0 1rem 0;
-  color: #495057;
+  color: var(--gray-550);
   font-size: 1.1rem;
 }
 
@@ -719,7 +719,7 @@ export default {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
   padding: 1rem;
-  background: #f8f9fa;
+  background: var(--gray-600-light);
   border-radius: 8px;
 }
 

--- a/src/frontend/src/components/TaskList.vue
+++ b/src/frontend/src/components/TaskList.vue
@@ -457,7 +457,7 @@ export default {
   align-items: center;
   gap: 0.5rem;
   font-size: 1.25rem;
-  color: #495057;
+  color: var(--gray-550);
 }
 
 .refresh-btn {
@@ -475,7 +475,7 @@ export default {
   gap: 1rem;
   margin-bottom: 1.5rem;
   padding: 1rem;
-  background: #f8f9fa;
+  background: var(--gray-600-light);
   border-radius: 8px;
 }
 
@@ -487,7 +487,7 @@ export default {
 
 .stat-count {
   font-weight: 600;
-  color: #495057;
+  color: var(--gray-550);
 }
 
 .loading-state {
@@ -504,13 +504,13 @@ export default {
   align-items: center;
   gap: 0.5rem;
   padding: 2rem;
-  color: #6c757d;
+  color: var(--gray-650);
 }
 
 .empty-state {
   text-align: center;
   padding: 3rem;
-  color: #6c757d;
+  color: var(--gray-650);
 }
 
 .empty-icon {
@@ -521,7 +521,7 @@ export default {
 
 .empty-state h3 {
   margin: 0 0 0.5rem 0;
-  color: #495057;
+  color: var(--gray-550);
 }
 
 .task-table {
@@ -536,7 +536,7 @@ export default {
 
 .file-icon {
   font-size: 1.5rem;
-  color: #6366f1;
+  color: var(--primary-500);
   flex-shrink: 0;
 }
 
@@ -549,7 +549,7 @@ export default {
 
 .filename {
   font-weight: 500;
-  color: #495057;
+  color: var(--gray-550);
   word-break: break-all;
 }
 
@@ -628,7 +628,7 @@ export default {
 
 :deep(.task-progress .p-progressbar) {
   border-radius: 4px;
-  background: #e5e7eb;
+  background: var(--gray-200);
 }
 
 .eta {
@@ -645,7 +645,7 @@ export default {
 
 .date {
   font-weight: 500;
-  color: #495057;
+  color: var(--gray-550);
 }
 
 .time {
@@ -759,19 +759,19 @@ export default {
   padding: 1rem 0.75rem;
   font-size: 0.95rem;
   font-weight: 600;
-  color: #374151;
-  background: #f8f9fa;
-  border-bottom: 2px solid #e5e7eb;
+  color: var(--gray-700);
+  background: var(--gray-600-light);
+  border-bottom: 2px solid var(--gray-200);
 }
 
 :deep(.task-table .p-datatable-tbody > tr > td) {
   padding: 1rem 0.75rem;
   vertical-align: top;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--gray-200);
 }
 
 :deep(.task-table .p-datatable-tbody > tr:hover) {
-  background: #f8f9fa;
+  background: var(--gray-600-light);
 }
 
 /* Column widths */

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -31,10 +31,25 @@
   --gray-300: #d1d5db;
   --gray-400: #9ca3af;
   --gray-500: #6b7280;
+  --gray-600-light: #f8fafc;
+  --gray-650-light: #f1f5f9;
+  --gray-625-light: #f1f3f4;
   --gray-600: #4b5563;
   --gray-700: #374151;
   --gray-800: #1f2937;
   --gray-900: #111827;
+
+  /* Additional neutral colors */
+  --gray-550: #495057;
+  --gray-650: #6c757d;
+
+  /* Brand and info palettes */
+  --brand-400: #5b6de8;
+  --brand-500: #667eea;
+  --brand-700: #764ba2;
+  --info-400: #60a5fa;
+  --info-500: #3b82f6;
+  --info-600: #2563eb;
 
   /* Success, warning, error colors */
   --success-50: #f0fdf4;
@@ -552,8 +567,8 @@ a:hover {
 
 /* Info Toast - 青系の目立つ配色 */
 .p-toast .p-toast-message.p-toast-message-info {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  border-color: #60a5fa;
+  background: linear-gradient(135deg, var(--info-500) 0%, var(--info-600) 100%);
+  border-color: var(--info-400);
   color: white;
 }
 


### PR DESCRIPTION
## Summary
- define brand and neutral colors in `global.css`
- use color variables in various Vue components

## Testing
- `npm run test:unit-python` *(fails: `source: not found`)*
- `npm test --prefix tests/unit-js` *(fails: `ERR_MODULE_NOT_FOUND`)*

------
https://chatgpt.com/codex/tasks/task_e_684dcb4370ec832e837098fc330e66d9