### PR TITLE
Fix Playwright tests

### DIFF
--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <header class="app-header">
+  <header class="app-header" data-testid="main-header">
       <h1 class="app-title">
         <RouterLink :to="{ name: 'dashboard' }" class="home-link">
           <i class="pi pi-video"></i>

--- a/src/frontend/src/components/FileUploader.vue
+++ b/src/frontend/src/components/FileUploader.vue
@@ -80,6 +80,7 @@
                         label="ファイルを選択"
                         icon="pi pi-folder-open"
                         class="upload-button-primary"
+                        data-testid="file-upload-area"
                         :loading="loading"
                         @click="triggerFileSelect"
                       />

--- a/src/frontend/src/components/MinutesViewer.vue
+++ b/src/frontend/src/components/MinutesViewer.vue
@@ -23,7 +23,7 @@
       />
     </div>
 
-    <div v-else-if="minutes" class="minutes-content">
+    <div v-else-if="minutes" class="minutes-content" data-testid="minutes-content">
       <!-- Header -->
       <div class="minutes-header">
         <div class="header-info">
@@ -59,6 +59,7 @@
             :model="downloadOptions"
             @click="downloadMarkdown"
             class="download-button"
+            data-testid="download-button"
           />
         </div>
       </div>

--- a/src/frontend/src/components/TaskDetailModal.vue
+++ b/src/frontend/src/components/TaskDetailModal.vue
@@ -6,6 +6,7 @@
     :closable="true"
     :draggable="false"
     class="task-detail-modal"
+    data-testid="task-detail-modal"
     :style="{ width: '90vw', maxWidth: '800px' }"
   >
     <div v-if="task" class="task-detail-content">
@@ -56,7 +57,7 @@
         </div>
 
         <!-- Step Timeline -->
-        <Timeline :value="processSteps" layout="vertical" class="step-timeline">
+        <Timeline :value="processSteps" layout="vertical" class="step-timeline" data-testid="processing-timeline">
           <template #marker="{ item }">
             <div class="step-marker" :class="getStepMarkerClass(item)">
               <i :class="getStepIcon(item)"></i>
@@ -64,12 +65,13 @@
           </template>
 
           <template #content="{ item }">
-            <div class="step-content">
+            <div class="step-content" :data-testid="`step-${item.name}`">
               <div class="step-header">
                 <h4>{{ item.label }}</h4>
                 <Badge
                   :value="getStepStatusLabel(item.status)"
                   :severity="getStepStatusSeverity(item.status)"
+                  data-testid="step-status"
                 />
               </div>
 
@@ -105,7 +107,7 @@
         class="error-section"
       >
         <h3>エラー詳細</h3>
-        <Message severity="error" :closable="false" class="error-message">
+        <Message severity="error" :closable="false" class="error-message" data-testid="error-message">
           <div class="error-content">
             <strong>エラーメッセージ:</strong>
             <pre>{{ task.error_message }}</pre>
@@ -141,6 +143,7 @@
           label="再実行"
           icon="pi pi-refresh"
           class="p-button-warning"
+          data-testid="retry-button"
           @click="handleRetry"
           :loading="retrying"
         />
@@ -169,6 +172,7 @@
           label="閉じる"
           icon="pi pi-times"
           class="p-button-secondary"
+          data-testid="modal-close"
           @click="close"
         />
       </div>

--- a/src/frontend/src/components/TaskList.vue
+++ b/src/frontend/src/components/TaskList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="task-list">
+  <div class="task-list" data-testid="task-list">
     <Card>
       <template #title>
         <div class="title-section">
@@ -36,6 +36,7 @@
         <!-- Loading State - 初期化されていない場合のみ表示 -->
         <div v-if="loading && !initialized" class="loading-state">
           <ProgressSpinner
+            data-testid="loading-spinner"
             strokeWidth="4"
             fill="transparent"
             animationDuration="1s"
@@ -53,6 +54,7 @@
         <!-- Loading overlay for manual refresh - 手動更新時のみ表示 -->
         <div v-else-if="loading && initialized && tasks.length === 0" class="refresh-loading">
           <ProgressSpinner
+            data-testid="loading-spinner"
             strokeWidth="3"
             fill="transparent"
             animationDuration="1s"
@@ -103,6 +105,7 @@
             <template #body="{ data }">
               <div class="status-cell">
                 <Badge
+                  data-testid="status-badge"
                   :value="getStatusLabel(data.status)"
                   :severity="getStatusSeverity(data.status)"
                 />
@@ -133,6 +136,7 @@
                   :value="data.overall_progress || 0"
                   :showValue="false"
                   class="task-progress"
+                  :data-testid="`progress-bar-${data.task_id}`"
                 />
                 <small
                   v-if="data.status === 'processing' && data.estimated_time"
@@ -187,6 +191,7 @@
                     showDelay: 300,
                     hideDelay: 100
                   }"
+                  :data-testid="`view-minutes-${data.task_id}`"
                   @click="viewMinutes(data)"
                 />
 
@@ -379,13 +384,13 @@ export default {
     }
 
     const getRowClass = (data) => {
-      // 完了したタスクのみクリック可能であることを視覚的に示す
+      const base = `task-row-${data.task_id}`
       if (data.status === 'completed') {
-        return 'clickable-row completed-row'
-      } else if (data.status === 'processing' || data.status === 'pending' || data.status === 'failed') {
-        return 'clickable-row processing-row'
+        return `${base} clickable-row completed-row`
+      } else if (['processing', 'pending', 'failed'].includes(data.status)) {
+        return `${base} clickable-row processing-row`
       }
-      return ''
+      return base
     }
 
     const getStatusLabel = status => {

--- a/tests/e2e/basic-flow.spec.js
+++ b/tests/e2e/basic-flow.spec.js
@@ -9,9 +9,9 @@ test.describe('基本的なファイルアップロード・処理フロー', ()
     await page.goto('/');
     
     // ダッシュボードの基本要素が表示されることを確認
-    await expect(page.getByTestId('main-header')).toBeVisible();
-    await expect(page.getByTestId('file-upload-area')).toBeVisible();
-    await expect(page.getByTestId('task-list')).toBeVisible();
+    await expect(page.locator('header.app-header')).toBeVisible();
+    await expect(page.locator('button.upload-button-primary')).toBeVisible();
+    await expect(page.locator('div.task-list')).toBeVisible();
   });
 
   test('シナリオ1: 単一動画ファイルの正常処理 @basic', async ({ page }) => {
@@ -24,12 +24,13 @@ test.describe('基本的なファイルアップロード・処理フロー', ()
     
     // Step 4: タスク一覧に新しいタスクが追加されることを確認
     console.log('Step 4: タスク追加確認');
-    const taskRows = page.getByTestId(/^task-row-/);
+    const taskRows = page.locator('tr[class*="task-row-"]');
     await expect(taskRows.first()).toBeVisible();
     
     // タスクIDを取得
     const firstTaskRow = taskRows.first();
-    const taskId = await firstTaskRow.getAttribute('data-testid').then(id => id.replace('task-row-', ''));
+    const classAttr = await firstTaskRow.getAttribute('class');
+    const taskId = classAttr.match(/task-row-([\w-]+)/)[1];
     
     // Step 5: タスクステータスが「processing」に変更されることを確認
     console.log('Step 5: 処理開始確認');
@@ -53,7 +54,7 @@ test.describe('基本的なファイルアップロード・処理フロー', ()
     ]);
     
     // モーダルを閉じる
-    await page.getByTestId('modal-close').click();
+    await page.locator('[data-testid="modal-close"]').click();
     await expect(modal).not.toBeVisible();
     
     // Step 8-9: 処理完了まで待機
@@ -65,13 +66,13 @@ test.describe('基本的なファイルアップロード・処理フロー', ()
     
     // Step 10-11: 議事録画面への遷移
     console.log('Step 10-11: 議事録表示確認');
-    const viewButton = page.getByTestId(`view-minutes-${taskId}`);
+    const viewButton = page.locator(`[data-testid="view-minutes-${taskId}"]`);
     await expect(viewButton).toBeVisible();
     await viewButton.click();
     
     // 議事録画面の表示確認
-    await expect(page.getByTestId('minutes-content')).toBeVisible();
-    await expect(page.getByTestId('transcript-content')).toBeVisible();
+    await expect(page.locator('[data-testid="minutes-content"]')).toBeVisible();
+    await expect(page.locator('.transcription-content')).toBeVisible();
     
     // Step 12: ダウンロード機能の確認
     console.log('Step 12: ダウンロード機能確認');
@@ -95,10 +96,10 @@ test.describe('基本的なファイルアップロード・処理フロー', ()
       await helpers.testResponsiveLayout(viewport);
       
       // ファイルアップロード機能が動作することを確認
-      await expect(page.getByTestId('file-upload-area')).toBeVisible();
+      await expect(page.locator('button.upload-button-primary')).toBeVisible();
       
       // タスクリストが適切に表示されることを確認
-      await expect(page.getByTestId('task-list')).toBeVisible();
+      await expect(page.locator('div.task-list')).toBeVisible();
     }
   });
 

--- a/tests/e2e/parallel-processing.spec.js
+++ b/tests/e2e/parallel-processing.spec.js
@@ -9,9 +9,9 @@ test.describe('複数ファイル並行処理テスト', () => {
     await page.goto('/');
     
     // ダッシュボードの表示確認
-    await expect(page.getByTestId('main-header')).toBeVisible();
-    await expect(page.getByTestId('file-upload-area')).toBeVisible();
-    await expect(page.getByTestId('task-list')).toBeVisible();
+    await expect(page.locator('header.app-header')).toBeVisible();
+    await expect(page.locator('button.upload-button-primary')).toBeVisible();
+    await expect(page.locator('div.task-list')).toBeVisible();
   });
 
   test('シナリオ2: 複数ファイルの並行処理 @parallel', async ({ page }) => {
@@ -35,14 +35,15 @@ test.describe('複数ファイル並行処理テスト', () => {
     
     // Step 2: 3つのタスクが並行して処理されることを確認
     console.log('Step 2: 並行処理の確認');
-    const taskRows = page.getByTestId(/^task-row-/);
+    const taskRows = page.locator('tr[class*="task-row-"]');
     await expect(taskRows).toHaveCount(3);
     
     // 各タスクのIDを取得
     const taskIds = [];
     for (let i = 0; i < 3; i++) {
       const taskRow = taskRows.nth(i);
-      const taskId = await taskRow.getAttribute('data-testid').then(id => id.replace('task-row-', ''));
+      const classAttr = await taskRow.getAttribute('class');
+      const taskId = classAttr.match(/task-row-([\w-]+)/)[1];
       taskIds.push(taskId);
     }
     
@@ -64,7 +65,7 @@ test.describe('複数ファイル並行処理テスト', () => {
     for (const taskId of taskIds) {
       try {
         await helpers.waitForProgress(taskId, 5); // 最低5%の進捗を待機
-        const progressBar = page.getByTestId(`progress-bar-${taskId}`);
+        const progressBar = page.locator(`[data-testid="progress-bar-${taskId}"]`);
         const progressValue = await progressBar.getAttribute('aria-valuenow');
         progressValues.push(parseInt(progressValue) || 0);
         console.log(`Task ${taskId} progress: ${progressValue}%`);
@@ -159,10 +160,10 @@ test.describe('複数ファイル並行処理テスト', () => {
       const currentPage = pages[i];
       
       // 各ページでタスクリストが表示されることを確認
-      await expect(currentPage.getByTestId('task-list')).toBeVisible();
+      await expect(currentPage.locator('div.task-list')).toBeVisible();
       
       // 各ページで独立したタスクが存在することを確認
-      const taskRows = currentPage.getByTestId(/^task-row-/);
+      const taskRows = currentPage.locator('tr[class*="task-row-"]');
       const taskCount = await taskRows.count();
       console.log(`Page ${i + 1}: ${taskCount} tasks found`);
       
@@ -204,8 +205,8 @@ test.describe('複数ファイル並行処理テスト', () => {
     console.log('Performance metrics during load:', performanceMetrics);
     
     // UI の応答性確認
-    await expect(page.getByTestId('file-upload-area')).toBeVisible();
-    await expect(page.getByTestId('task-list')).toBeVisible();
+    await expect(page.locator('button.upload-button-primary')).toBeVisible();
+    await expect(page.locator('div.task-list')).toBeVisible();
     
     // 追加ファイルのアップロードが可能であることを確認
     try {

--- a/tests/e2e/ui-interaction.spec.js
+++ b/tests/e2e/ui-interaction.spec.js
@@ -9,9 +9,9 @@ test.describe('UIインタラクション・レスポンシブテスト', () => 
     await page.goto('/');
     
     // ダッシュボードの表示確認
-    await expect(page.getByTestId('main-header')).toBeVisible();
-    await expect(page.getByTestId('file-upload-area')).toBeVisible();
-    await expect(page.getByTestId('task-list')).toBeVisible();
+    await expect(page.locator('header.app-header')).toBeVisible();
+    await expect(page.locator('button.upload-button-primary')).toBeVisible();
+    await expect(page.locator('div.task-list')).toBeVisible();
   });
 
   test('シナリオ8: レスポンシブデザイン @responsive', async ({ page }) => {
@@ -47,22 +47,22 @@ test.describe('UIインタラクション・レスポンシブテスト', () => 
     console.log('タッチデバイス操作テスト開始');
     
     // タッチジェスチャーでのファイルアップロード
-    const uploadArea = page.getByTestId('file-upload-area');
+    const uploadArea = page.locator('button.upload-button-primary');
     await expect(uploadArea).toBeVisible();
     
     // タップ操作の確認
     await uploadArea.tap();
     
     // スワイプ操作でタスクリストを操作
-    const taskList = page.getByTestId('task-list');
+    const taskList = page.locator('div.task-list');
     await expect(taskList).toBeVisible();
     
     // モバイルメニューの表示確認
-    const mobileMenuButton = page.getByTestId('mobile-menu-button');
+    const mobileMenuButton = page.locator('[data-testid="mobile-menu-button"]');
     if (await mobileMenuButton.isVisible()) {
       await mobileMenuButton.tap();
       
-      const mobileMenu = page.getByTestId('mobile-menu');
+      const mobileMenu = page.locator('[data-testid="mobile-menu"]');
       await expect(mobileMenu).toBeVisible();
       
       // メニューを閉じる
@@ -77,8 +77,8 @@ test.describe('UIインタラクション・レスポンシブテスト', () => 
     console.log(`ブラウザ互換性テスト開始: ${browserName}`);
     
     // 基本機能の動作確認
-    await expect(page.getByTestId('file-upload-area')).toBeVisible();
-    await expect(page.getByTestId('task-list')).toBeVisible();
+    await expect(page.locator('button.upload-button-primary')).toBeVisible();
+    await expect(page.locator('div.task-list')).toBeVisible();
     
     // CSS Grid/Flexboxサポート確認
     const layoutElements = await page.locator('[data-testid*="layout"]').all();
@@ -143,7 +143,7 @@ test.describe('UIインタラクション・レスポンシブテスト', () => 
     await page.keyboard.press('Enter');
     
     // Escape キーでモーダル閉じる操作
-    const modal = page.getByTestId('file-chooser-modal');
+    const modal = page.locator('[data-testid="file-chooser-modal"]');
     if (await modal.isVisible()) {
       await page.keyboard.press('Escape');
       await expect(modal).not.toBeVisible();
@@ -204,7 +204,7 @@ test.describe('UIインタラクション・レスポンシブテスト', () => 
     console.log('テーマ切り替えテスト開始');
     
     // ライトモードの確認
-    const themeToggle = page.getByTestId('theme-toggle');
+    const themeToggle = page.locator('[data-testid="theme-toggle"]');
     if (await themeToggle.isVisible()) {
       // 現在のテーマを確認
       const currentTheme = await page.getAttribute('html', 'data-theme');
@@ -237,7 +237,7 @@ test.describe('UIインタラクション・レスポンシブテスト', () => 
   test('言語切り替え @ui @i18n', async ({ page }) => {
     console.log('言語切り替えテスト開始');
     
-    const languageSelector = page.getByTestId('language-selector');
+    const languageSelector = page.locator('[data-testid="language-selector"]');
     if (await languageSelector.isVisible()) {
       // 現在の言語を確認
       const currentLang = await page.getAttribute('html', 'lang');
@@ -264,7 +264,7 @@ test.describe('UIインタラクション・レスポンシブテスト', () => 
           expect(newLang).not.toBe(currentLang);
           
           // UI テキストが変更されたことを確認
-          const headerText = await page.getByTestId('main-header').textContent();
+          const headerText = await page.locator('header.app-header').textContent();
           console.log('Header text after language change:', headerText);
         }
       }
@@ -300,7 +300,7 @@ test.describe('UIインタラクション・レスポンシブテスト', () => 
     // ローディングアニメーションの確認
     await helpers.uploadFile('test-video-small.mp4');
     
-    const loadingSpinner = page.getByTestId('loading-spinner');
+    const loadingSpinner = page.locator('[data-testid="loading-spinner"]');
     if (await loadingSpinner.isVisible()) {
       // スピナーアニメーションの確認
       const spinnerStyles = await loadingSpinner.evaluate(el => {
@@ -325,24 +325,24 @@ async function testMainFunctionsAtViewport(page, viewport) {
   console.log(`  Testing main functions at ${viewport.name}`);
   
   // ファイルアップロードエリアの表示・操作確認
-  const uploadArea = page.getByTestId('file-upload-area');
+  const uploadArea = page.locator('button.upload-button-primary');
   await expect(uploadArea).toBeVisible();
   
   // タスクリストの表示確認
-  const taskList = page.getByTestId('task-list');
+  const taskList = page.locator('div.task-list');
   await expect(taskList).toBeVisible();
   
   // モバイルサイズの場合、ハンバーガーメニューの確認
   if (viewport.width < 768) {
-    const mobileMenu = page.getByTestId('mobile-menu-button');
+    const mobileMenu = page.locator('[data-testid="mobile-menu-button"]');
     if (await mobileMenu.isVisible()) {
       await mobileMenu.click();
       
-      const menuPanel = page.getByTestId('mobile-menu-panel');
+      const menuPanel = page.locator('[data-testid="mobile-menu-panel"]');
       await expect(menuPanel).toBeVisible();
       
       // メニューを閉じる
-      await page.getByTestId('mobile-menu-close').click();
+      await page.locator('[data-testid="mobile-menu-close"]').click();
       await expect(menuPanel).not.toBeVisible();
     }
   }

--- a/tests/e2e/utils/test-helpers.js
+++ b/tests/e2e/utils/test-helpers.js
@@ -25,7 +25,7 @@ class TestHelpers {
     
     // ファイルアップロード
     const fileChooserPromise = this.page.waitForEvent('filechooser');
-    await this.page.getByTestId('file-upload-area').click();
+    await this.page.locator('button.upload-button-primary').click();
     const fileChooser = await fileChooserPromise;
     await fileChooser.setFiles(filePath);
 
@@ -72,8 +72,8 @@ class TestHelpers {
    * @param {string} taskId - タスクID
    */
   async getTaskStatus(taskId) {
-    const taskRow = this.page.getByTestId(`task-row-${taskId}`);
-    const statusBadge = taskRow.getByTestId('status-badge');
+    const taskRow = this.page.locator(`tr.task-row-${taskId}`);
+    const statusBadge = taskRow.locator('[data-testid="status-badge"]');
     const statusText = await statusBadge.textContent();
     return statusText.toLowerCase();
   }
@@ -84,7 +84,7 @@ class TestHelpers {
    * @param {number} minProgress - 最小進捗パーセンテージ
    */
   async waitForProgress(taskId, minProgress = 10) {
-    const progressBar = this.page.getByTestId(`progress-bar-${taskId}`);
+    const progressBar = this.page.locator(`tr.task-row-${taskId} [data-testid="progress-bar-${taskId}"]`);
     
     await expect(progressBar).toBeVisible();
     
@@ -154,9 +154,9 @@ class TestHelpers {
     await this.page.waitForTimeout(1000); // レイアウト調整を待機
     
     // 主要要素の表示確認
-    await expect(this.page.getByTestId('main-header')).toBeVisible();
-    await expect(this.page.getByTestId('file-upload-area')).toBeVisible();
-    await expect(this.page.getByTestId('task-list')).toBeVisible();
+    await expect(this.page.locator('header.app-header')).toBeVisible();
+    await expect(this.page.locator('button.upload-button-primary')).toBeVisible();
+    await expect(this.page.locator('div.task-list')).toBeVisible();
   }
 
   /**
@@ -191,7 +191,7 @@ class TestHelpers {
     const downloadPromise = this.page.waitForEvent('download');
     
     // ダウンロードボタンをクリック
-    await this.page.getByTestId('download-button').click();
+    await this.page.locator('[data-testid="download-button"]').click();
     
     const download = await downloadPromise;
     expect(download.suggestedFilename()).toBe(expectedFileName);
@@ -208,14 +208,14 @@ class TestHelpers {
    * @param {string} expectedError - 期待するエラーメッセージ
    */
   async checkErrorMessage(expectedError) {
-    const errorDialog = this.page.getByTestId('error-dialog');
+    const errorDialog = this.page.locator('[data-testid="error-dialog"]');
     await expect(errorDialog).toBeVisible();
     
     const errorText = await errorDialog.locator('.error-message').textContent();
     expect(errorText).toContain(expectedError);
     
     // エラーダイアログを閉じる
-    await this.page.getByTestId('error-dialog-close').click();
+    await this.page.locator('[data-testid="error-dialog-close"]').click();
     await expect(errorDialog).not.toBeVisible();
   }
 
@@ -224,10 +224,10 @@ class TestHelpers {
    * @param {string} taskId - タスクID
    */
   async openTaskDetailModal(taskId) {
-    const taskRow = this.page.getByTestId(`task-row-${taskId}`);
+    const taskRow = this.page.locator(`tr.task-row-${taskId}`);
     await taskRow.click();
-    
-    const modal = this.page.getByTestId('task-detail-modal');
+
+    const modal = this.page.locator('[data-testid="task-detail-modal"]');
     await expect(modal).toBeVisible();
     
     return modal;
@@ -238,15 +238,15 @@ class TestHelpers {
    * @param {Array} expectedSteps - 期待する処理ステップ
    */
   async checkProcessingSteps(expectedSteps) {
-    const timeline = this.page.getByTestId('processing-timeline');
+    const timeline = this.page.locator('[data-testid="processing-timeline"]');
     await expect(timeline).toBeVisible();
     
     for (const step of expectedSteps) {
-      const stepElement = this.page.getByTestId(`step-${step.name}`);
+      const stepElement = this.page.locator(`[data-testid="step-${step.name}"]`);
       await expect(stepElement).toBeVisible();
       
       if (step.status) {
-        const statusElement = stepElement.getByTestId('step-status');
+        const statusElement = stepElement.locator('[data-testid="step-status"]');
         await expect(statusElement).toHaveAttribute('data-status', step.status);
       }
     }
@@ -262,7 +262,7 @@ class TestHelpers {
     );
     
     const fileChooserPromise = this.page.waitForEvent('filechooser');
-    await this.page.getByTestId('file-upload-area').click();
+    await this.page.locator('button.upload-button-primary').click();
     const fileChooser = await fileChooserPromise;
     await fileChooser.setFiles(filePaths);
     


### PR DESCRIPTION
## Summary
- attach test ids to key frontend components
- make DataTable rows identifiable
- update Playwright helper utilities
- update E2E specs to use new selectors

## Testing
- `./static-analysis.sh` *(fails: No module named flake8)*
- `npm test` *(fails: Cannot find module 'vitest/dist/cli-wrapper.js')*

------
https://chatgpt.com/codex/tasks/task_e_68500d8c5808832eb72e3561ac0ed9cd