### PR TITLE
Add missing JS utility tests

### DIFF
--- a/tests/unit-js/utils/dateUtils.test.js
+++ b/tests/unit-js/utils/dateUtils.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatDateTime,
+  formatDate,
+  formatTime,
+  formatRelativeTime,
+  formatDuration,
+  formatFileSize
+} from '@/utils/dateUtils'
+
+describe('dateUtils', () => {
+  it('formats date and time with timezone option', () => {
+    const result = formatDateTime('2024-01-01T12:34:56Z', { timeZone: 'UTC' })
+    expect(result).toBe('2024/01/01 12:34')
+  })
+
+  it('returns empty string for invalid input', () => {
+    expect(formatDateTime('invalid')).toBe('')
+  })
+
+  it('formatDate returns date string', () => {
+    const res = formatDate('2024-01-01T12:34:56Z')
+    expect(res).toBe('2024/01/01 12:34')
+  })
+
+  it('formatTime returns time string', () => {
+    const res = formatTime('2024-01-01T12:34:56Z')
+    expect(res).toBe('2024/01/01 12:34')
+  })
+
+  it('formatRelativeTime displays minutes ago', () => {
+    const date = new Date(Date.now() - 5 * 60 * 1000)
+    expect(formatRelativeTime(date)).toBe('5分前')
+  })
+
+  it('formatDuration handles hours and minutes', () => {
+    expect(formatDuration(3661000)).toBe('1時間1分1秒')
+    expect(formatDuration(90000)).toBe('1分30秒')
+    expect(formatDuration(0)).toBe('0秒')
+  })
+
+  it('formatFileSize converts bytes', () => {
+    expect(formatFileSize(0)).toBe('0 Bytes')
+    expect(formatFileSize(1024)).toBe('1 KB')
+    expect(formatFileSize(1024 * 1024)).toBe('1 MB')
+  })
+})

--- a/tests/unit-js/utils/markdown.test.js
+++ b/tests/unit-js/utils/markdown.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('highlight.js', () => ({
+  default: {
+    getLanguage: () => true,
+    highlight: () => ({ value: 'hl' })
+  }
+}))
+
+vi.mock('dompurify', () => ({
+  default: { sanitize: vi.fn(html => html) }
+}))
+
+vi.mock('marked', () => {
+  const lexer = md => {
+    const tokens = []
+    const regex = /^(#{1,6})\s*(.+)$/gm
+    let match
+    while ((match = regex.exec(md))) {
+      tokens.push({ type: 'heading', depth: match[1].length, text: match[2] })
+    }
+    return tokens
+  }
+  const parse = vi.fn(md => `<p>${md}</p>`)
+  const setOptions = vi.fn()
+  return { marked: { Renderer: class {}, lexer, parse, setOptions } }
+})
+
+import { parseMarkdown, extractTableOfContents, getMarkdownWordCount } from '@/utils/markdown'
+import DOMPurify from 'dompurify'
+import { marked } from 'marked'
+
+describe('markdown utils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('parses markdown and sanitizes result', () => {
+    const html = parseMarkdown('**bold**')
+    expect(marked.parse).toHaveBeenCalledWith('**bold**')
+    expect(DOMPurify.default.sanitize).toHaveBeenCalled()
+    expect(html).toBe('<p>**bold**</p>')
+  })
+
+  it('extracts table of contents', () => {
+    const md = '# Title\n\n## Section 1\nText\n### SubSection\nMore'
+    const toc = extractTableOfContents(md)
+    expect(toc).toEqual([
+      { level: 1, text: 'Title', id: 'title' },
+      { level: 2, text: 'Section 1', id: 'section-1' },
+      { level: 3, text: 'SubSection', id: 'subsection' }
+    ])
+  })
+
+  it('counts words from markdown', () => {
+    const count = getMarkdownWordCount('これは**テスト**です')
+    expect(count).toBe(9)
+  })
+})


### PR DESCRIPTION
## Summary
- add date/time utility tests
- add markdown utility tests

## Testing
- `npm run test:unit-js` *(fails: Cannot find module 'vitest/dist/cli-wrapper.js')*

------
https://chatgpt.com/codex/tasks/task_e_68500dd9a5c0832e92da3f73a4848a44